### PR TITLE
Small ECS Geo Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ## Logstash Pipeline (This Repository)
 logstash pipeline configurations
-https://github.com/corelight/ecs-logstash-mappings 
 
 ## Elasticsearch templates
 Index templates,component templates, settings, mappings

--- a/pipeline/0098-corelight-ecs-all-add-etl-info-filter.conf
+++ b/pipeline/0098-corelight-ecs-all-add-etl-info-filter.conf
@@ -10,8 +10,11 @@ filter {
   if [@metadata][z_no_reuse][event_type] == "corelight" {
     ruby {
       code => "event.set('[@metadata][etl][processed_time]', Time.now().utc);"
-      add_field => { "[@metadata][etl][pipeline]" => "filter-ruby-28d21a6a57d6-20220310.01" }
-      tag_on_exception => "_rubyexception-28d21a6a57d6-add_etl_process_time-20220310.01"
+      add_field => {
+        "[@metadata][etl][pipeline]" => "filter-ruby-28d21a6a57d6-20220310.01" 
+        "[@metadata][etl][processed_time]" => "%{[event][ingested]}"
+      }
+      tag_on_exception => "_rubyexception-28d21a6a57d6-add_etl_process_time-2022032201.01"
       id => "filter-ruby-28d21a6a57d6"
     }
   }

--- a/pipeline/0098-corelight-ecs-all-add-etl-info-filter.conf
+++ b/pipeline/0098-corelight-ecs-all-add-etl-info-filter.conf
@@ -12,7 +12,7 @@ filter {
       code => "event.set('[@metadata][etl][processed_time]', Time.now().utc);"
       add_field => {
         "[@metadata][etl][pipeline]" => "filter-ruby-28d21a6a57d6-20220310.01" 
-        "[@metadata][etl][processed_time]" => "%{[event][ingested]}"
+        "[event][ingested]" => "%{[@metadata][etl][processed_time]}"
       }
       tag_on_exception => "_rubyexception-28d21a6a57d6-add_etl_process_time-2022032201.01"
       id => "filter-ruby-28d21a6a57d6"

--- a/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
@@ -56,9 +56,11 @@ filter {
             remove_field => [
               "[destination][geo][ip]",
               "[destination][geo][latitude]",
-              "[destination][geo][longitude]"
+              "[destination][geo][longitude]",
+              "[destination][geo][country_code2]",
+              "[destination][geo][country_code3]"
             ]
-            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-destination_ip", "_geoip_lookup_failure-c2c25d701e37-20220321.01" ]
+            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-destination_ip", "_geoip_lookup_failure-c2c25d701e37-20220321.02" ]
             id => "filter-geoip-c2c25d701e37"
           }
           geoip {

--- a/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
@@ -63,6 +63,19 @@ filter {
             tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-destination_ip", "_geoip_lookup_failure-c2c25d701e37-20220321.02" ]
             id => "filter-geoip-c2c25d701e37"
           }
+          # Make ECS compliant
+          if [@metadata][destination_ip_geo_location_successful] {
+            mutate {
+              rename => {
+                "[destination][geo][region_code]" => "[destination][geo][region_iso_code]"
+              }
+              add_field => {
+                "[@metadata][etl][pipeline]" => "filter-mutate-8e679e54306a-20220321.01"
+              }
+              tag_on_failure => "_mutate_error-8e679e54306a-20220321.01"
+              id => "filter-mutate-8e679e54306a"
+            }
+          }
           geoip {
             source => "[destination][ip]"
             target => "[destination][as]"

--- a/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
@@ -38,7 +38,7 @@ filter {
             cache_size => 90000
             add_field =>  {
               "[@metadata][destination_ip_geo_location_successful]" => "true"
-              "[@metadata][etl][pipeline]" => "filter-geoip-c2c25d701e37-20220310.01"
+              "[@metadata][etl][pipeline]" => "filter-geoip-c2c25d701e37-20220321.02"
             }
             #fields => [
             #  "city_name",

--- a/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
@@ -53,8 +53,12 @@ filter {
             #  "postal_code",
             #  "region_name", "timezone"
             #]
-            remove_field => [ "[destination][geo][ip]" ]
-            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-destination_ip", "_geoip_lookup_failure-c2c25d701e37-20220310.01" ]
+            remove_field => [
+              "[destination][geo][ip]",
+              "[destination][geo][latitude]",
+              "[destination][geo][longitude]"
+            ]
+            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-destination_ip", "_geoip_lookup_failure-c2c25d701e37-20220321.01" ]
             id => "filter-geoip-c2c25d701e37"
           }
           geoip {

--- a/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-destination-ip-enrich-filter.conf
@@ -73,7 +73,7 @@ filter {
             id => "filter-geoip-7d8fcde65e8b"
           }
   
-          # Make ECS compliant if not
+          # Make ECS compliant
           if [@metadata][destination_ip_bgp_as_info_successful] {
             mutate {
               rename => {

--- a/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
@@ -63,6 +63,19 @@ filter {
             tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-host_ip", "_geoip_lookup_failure-638a52dd8041-20220321.02" ]
             id => "filter-geoip-638a52dd8041"
           }
+          # Make ECS compliant
+          if [@metadata][host_ip_geo_location_successful] {
+            mutate {
+              rename => {
+                "[host][geo][region_code]" => "[host][geo][region_iso_code]"
+              }
+              add_field => {
+                "[@metadata][etl][pipeline]" => "filter-mutate-27edd34c7fda-20220321.01"
+              }
+              tag_on_failure => "_mutate_error-27edd34c7fda-20220321.01"
+              id => "filter-mutate-27edd34c7fda"
+            }
+          }
           geoip {
             source => "[host][ip]"
             target => "[host][as]"

--- a/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
@@ -73,7 +73,7 @@ filter {
             id => "filter-geoip-df43921caacd"
           }
   
-          # Make ECS compliant if not
+          # Make ECS compliant
           if [@metadata][host_ip_bgp_as_info_successful] {
             mutate {
               rename => {

--- a/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
@@ -56,9 +56,11 @@ filter {
             remove_field => [
               "[host][geo][ip]",
               "[host][geo][latitude]",
-              "[host][geo][longitude]"
+              "[host][geo][longitude]",
+              "[host][geo][country_code2]",
+              "[host][geo][country_code3]"
             ]
-            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-host_ip", "_geoip_lookup_failure-638a52dd8041-20220321.01" ]
+            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-host_ip", "_geoip_lookup_failure-638a52dd8041-20220321.02" ]
             id => "filter-geoip-638a52dd8041"
           }
           geoip {

--- a/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
@@ -38,7 +38,7 @@ filter {
             cache_size => 90000
             add_field =>  {
               "[@metadata][host_ip_geo_location_successful]" => "true"
-              "[@metadata][etl][pipeline]" => "filter-geoip-638a52dd8041-20220310.01"
+              "[@metadata][etl][pipeline]" => "filter-geoip-638a52dd8041-20220321.02"
             }
             #fields => [
             #  "city_name",

--- a/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-host-ip-enrich-filter.conf
@@ -53,8 +53,12 @@ filter {
             #  "postal_code",
             #  "region_name", "timezone"
             #]
-            remove_field => [ "[host][geo][ip]" ]
-            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-host_ip", "_geoip_lookup_failure-638a52dd8041-20220310.01" ]
+            remove_field => [
+              "[host][geo][ip]",
+              "[host][geo][latitude]",
+              "[host][geo][longitude]"
+            ]
+            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-host_ip", "_geoip_lookup_failure-638a52dd8041-20220321.01" ]
             id => "filter-geoip-638a52dd8041"
           }
           geoip {

--- a/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
@@ -72,7 +72,7 @@ filter {
             id => "filter-geoip-77606e89a649"
           }
   
-          # Make ECS compliant if not
+          # Make ECS compliant
           if [@metadata][source_ip_bgp_as_info_successful] {
             mutate {
               rename => {

--- a/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
@@ -37,7 +37,7 @@ filter {
             cache_size => 90000
             add_field =>  {
               "[@metadata][source_ip_geo_location_successful]" => "true"
-              "[@metadata][etl][pipeline]" => "filter-geoip-d69adabce62a-20220310.01"
+              "[@metadata][etl][pipeline]" => "filter-geoip-d69adabce62a-20220321.02"
             }
             #fields => [
             #  "city_name",

--- a/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
@@ -52,8 +52,12 @@ filter {
             #  "postal_code",
             #  "region_name", "timezone"
             #]
-            remove_field => [ "[source][geo][ip]" ]
-            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-source_ip", "_geoip_lookup_failure-d69adabce62a-20220310.01" ]
+            remove_field => [
+              "[source][geo][ip]",
+              "[source][geo][latitude]",
+              "[source][geo][longitude]"
+            ]
+            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-source_ip", "_geoip_lookup_failure-d69adabce62a-20220321.01" ]
             id => "filter-geoip-d69adabce62a"
           }
           geoip {

--- a/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
@@ -62,6 +62,19 @@ filter {
             tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-source_ip", "_geoip_lookup_failure-d69adabce62a-20220321.02" ]
             id => "filter-geoip-d69adabce62a"
           }
+          # Make ECS compliant
+          if [@metadata][source_ip_geo_location_successful] {
+            mutate {
+              rename => {
+                "[source][geo][region_code]" => "[source][geo][region_iso_code]"
+              }
+              add_field => {
+                "[@metadata][etl][pipeline]" => "filter-mutate-4a7e0afdd8aa-20220321.01"
+              }
+              tag_on_failure => "_mutate_error-4a7e0afdd8aa-20220321.01"
+              id => "filter-mutate-4a7e0afdd8aa"
+            }
+          }
           geoip {
             source => "[source][ip]"
             target => "[source][as]"

--- a/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
+++ b/pipeline/8112-corelight-ecs-source-ip-enrich-filter.conf
@@ -55,9 +55,11 @@ filter {
             remove_field => [
               "[source][geo][ip]",
               "[source][geo][latitude]",
-              "[source][geo][longitude]"
+              "[source][geo][longitude]",
+              "[source][geo][country_code2]",
+              "[source][geo][country_code3]"
             ]
-            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-source_ip", "_geoip_lookup_failure-d69adabce62a-20220321.01" ]
+            tag_on_failure => [ "_geoip_lookup_failure", "parsefailure-geoip-city-source_ip", "_geoip_lookup_failure-d69adabce62a-20220321.02" ]
             id => "filter-geoip-d69adabce62a"
           }
           geoip {

--- a/pipeline/8999-corelight-ecs-final-filter.conf
+++ b/pipeline/8999-corelight-ecs-final-filter.conf
@@ -11,7 +11,7 @@ filter {
     if "parse-failure-critical" in [tags] {
       mutate {
         update => {
-            "[@metadata][@metadata][temporary_metadata_index_name_prefix]" => "parse-failures"
+            "[@metadata][temporary_metadata_index_name_prefix]" => "parse-failures"
             "[@metadata][temporary_metadata_index_name_suffix]" => "corelight"
         }
         add_field => {
@@ -37,7 +37,7 @@ filter {
     else if ![event][dataset] {
       mutate {
         update => {
-            "[@metadata][@metadata][temporary_metadata_index_name_prefix]" => "parse-failures"
+            "[@metadata][temporary_metadata_index_name_prefix]" => "parse-failures"
             "[@metadata][temporary_metadata_index_name_suffix]" => "corelight"
         }
         add_tag => [ "corelight-ecs-pipeline-error: missing [event][dataset]"]
@@ -65,7 +65,7 @@ filter {
   else if [@metadata][z_no_reuse][event_type] == "corelight-parse-failure" {
     mutate {
       update => {
-          "[@metadata][@metadata][temporary_metadata_index_name_prefix]" => "parse-failures"
+          "[@metadata][temporary_metadata_index_name_prefix]" => "parse-failures"
           "[@metadata][temporary_metadata_index_name_suffix]" => "corelight"
       }
       add_field => {


### PR DESCRIPTION
- remove redundant ecs long/lat geo location data
- remove geo country_code2 and geo country_code3 they are duplicates of geo country_iso_code. thus country_iso_code should be used in all searches/visualizations.
- rename  geo region_code to region_iso_code. thus region_iso_code should be used in all searches/visualizations.