### PR TITLE
v202208424.01

### DIFF
--- a/pipeline/0002-corelight-ecs-tcp-ssl_tls-input.conf.disabled
+++ b/pipeline/0002-corelight-ecs-tcp-ssl_tls-input.conf.disabled
@@ -10,6 +10,7 @@ input {
     #ecs_compatibility => "disabled" # If using logstash version 8.0.0 or higher, uncomment this line       
     dns_reverse_lookup_enabled => false
     port => 8615
+    codec => "json"
     ssl_enable = true
     
     #### SSL/TLS Parameters to change and set

--- a/pipeline/3111-corelight-ecs-conn-filter.conf
+++ b/pipeline/3111-corelight-ecs-conn-filter.conf
@@ -59,110 +59,73 @@ filter {
         "spcap_url" => "[labels][corelight][spcap][url]"
         "tunnel_parents" => "[log][id][tunnel_parents]"
       }
-      add_field => {
-        "[@metadata][etl][pipeline]" => "filter-mutate-1e85f5a781ad-main-conn-20220310.01"
+      convert => {
+        "[conn][local_orig]" => "string"
+        "[conn][local_resp]" => "string"
       }
-      tag_on_failure => "_mutate_error-1e85f5a781ad-20220310.01"
+      add_field => {
+        "[@metadata][etl][pipeline]" => "filter-mutate-1e85f5a781ad-main-conn-202208424.01"
+      }
+      tag_on_failure => "_mutate_error-1e85f5a781ad-202208424.01"
       id => "filter-mutate-1e85f5a781ad"
     }
     
-    # Calculated fields
-    if [conn][local_orig] {
-      mutate {
-        convert => {
-          "[conn][local_orig]" => "boolean"
-        }
-        add_field => {
-          "[@metadata][etl][pipeline]" => "filter-mutate-bf0c1adc7c4b-20220310.01"
-        }
-        tag_on_failure => "_mutate_error-bf0c1adc7c4b-20220310.01"
-        id => "filter-mutate-bf0c1adc7c4b"
-      }
-    }
-
-    else {
+    # [network[direction]
+    # orig <> resp
+    if [conn][local_orig] == "true" and [conn][local_resp] == "true" {
       mutate {
         add_field => {
-          "[network][direction]" => "unknown"
-          "[@metadata][etl][pipeline]" => "filter-mutate-f2d0b45f3e5e-20220310.01"
+          "[network][direction]" => "internal"
+          "[@metadata][etl][pipeline]" => "filter-mutate-fc3794e003c1-20220824.01"
         }
-        tag_on_failure => "_mutate_error-f2d0b45f3e5e-20220310.01"
-        id => "filter-mutate-f2d0b45f3e5e"
+        tag_on_failure => "_mutate_error-fc3794e003c1-20220824.01"
+        id => "filter-mutate-fc3794e003c1"
       }
     }
-
-    if [conn][local_resp] {
-      mutate { 
-        convert => {
-          "[conn][local_resp]" => "boolean" 
-        }
+    # orig > resp
+    else if [conn][local_orig] == "true" and [conn][local_resp] == "false" {
+      mutate {
         add_field => {
-          "[@metadata][etl][pipeline]" => "filter-mutate-f5cb96b5939f-20220310.01"
+          "[network][direction]" => "outbound"
+          "[@metadata][etl][pipeline]" => "filter-mutate-f36ee6e82f2f-20220824.01"
         }
-        tag_on_failure => "_mutate_error-f5cb96b5939f-20220310.01"
-        id => "filter-mutate-f5cb96b5939f"
+        tag_on_failure => "_mutate_error-f36ee6e82f2f-20220824.01"
+        id => "filter-mutate-f36ee6e82f2f"
       }
     }
-
-    else {
-      mutate { 
-        add_field => {
-          "[network][direction]" => "unknown"
-          "[@metadata][etl][pipeline]" => "filter-mutate-f8c86bb7ce33-20220310.01"
-        }
-        tag_on_failure => "_mutate_error-f8c86bb7ce33-20220310.01"
-        id => "filter-mutate-f8c86bb7ce33"
-      }
-    }
-
-    if [conn][local_orig] {
-
-      if [conn][local_resp] {
-        mutate { 
-          add_field => {
-            "[network][direction]" => "internal"
-          "[@metadata][etl][pipeline]" => "filter-mutate-8d89e74cdc8b-20220310.01"
-          }
-          tag_on_failure => "_mutate_error-8d89e74cdc8b-20220310.01"
-          id => "filter-mutate-8d89e74cdc8b"
-        }
-      }
-
-      else {
-        mutate { 
-          add_field => {
-            "[network][direction]" => "outbound"
-            "[@metadata][etl][pipeline]" => "filter-mutate-f757ee18cf54-20220310.01"
-          }
-          tag_on_failure => "_mutate_error-f757ee18cf54-20220310.01"
-          id => "filter-mutate-f757ee18cf54"
-        }
-      }
-
-    }
-
-    else if [conn][local_resp] {
-      mutate { 
+    # orig < resp
+    else if [conn][local_orig] == "false" and [conn][local_resp] == "true" {
+      mutate {
         add_field => {
           "[network][direction]" => "inbound"
-          "[@metadata][etl][pipeline]" => "filter-mutate-7210b898d319-20220310.01"
+          "[@metadata][etl][pipeline]" => "filter-mutate-e068370de923-20220824.01"
         }
-          tag_on_failure => "_mutate_error-7210b898d319-20220310.01"
-          id => "filter-mutate-7210b898d319"
+        tag_on_failure => "_mutate_error-e068370de923-20220824.01"
+        id => "filter-mutate-e068370de923"
       }
     }
-
-    else {
-      mutate { 
+    # orig && resp == false
+    else if [conn][local_orig] == "false" and [conn][local_resp] == "false" {
+      mutate {
         add_field => {
           "[network][direction]" => "external"
-          "[@metadata][etl][pipeline]" => "filter-mutate-b61d277e0433-20220310.01"
+          "[@metadata][etl][pipeline]" => "filter-mutate-698a844b4aec-20220824.01"
         }
-        tag_on_failure => "_mutate_error-b61d277e0433-20220310.01"
-        id => "filter-mutate-b61d277e0433"
+        tag_on_failure => "_mutate_error-698a844b4aec-20220824.01"
+        id => "filter-mutate-698a844b4aec"
       }
     }
-
+    else {
+      mutate {
+        add_field => {
+          "[network][direction]" => "unknown"
+          "[@metadata][etl][pipeline]" => "filter-mutate-0741a33b17eb-20220824.01"
+        }
+        tag_on_failure => "_mutate_error-0741a33b17eb-20220824.01"
+        id => "filter-mutate-0741a33b17eb"
+      }      
+    }
+      
     # Connection History
     if [network][connection][history] {
       ruby {

--- a/pipeline/3111-corelight-ecs-log4j-filter.conf
+++ b/pipeline/3111-corelight-ecs-log4j-filter.conf
@@ -28,13 +28,37 @@ filter {
       }
       copy => {
         "[url][domain]" => "[destination][domain]"
-        "[log4j][target_port]" => "[destination][port]"
       }
       add_field => {
-        "[@metadata][etl][pipeline]" => "filter-mutate-e6129a37700f-main-log4j-20220602.01"
+        "[@metadata][etl][pipeline]" => "filter-mutate-e6129a37700f-main-log4j-20220824.01"
       }
       tag_on_failure => "_mutate_error-e6129a37700f"
       id => "filter-mutate-e6129a37700f"
+    }
+    
+    if [log4j][target_port]  {
+      if [log4j][target_port] =~ /^\d/ {
+        mutate {
+          copy => {
+            "[log4j][target_port]" => "[destination][port]"
+          }
+          add_field => {
+            "[@metadata][etl][pipeline]" => "filter-mutate-c7ce31b520fd-20220824.01"
+          }
+          tag_on_failure => "_mutate_error-c7ce31b520fd"
+          id => "filter-mutate-c7ce31b520fd"
+        }
+      }
+      else {
+        mutate {
+          remove_field => [ "[log4j][target_port]" ]
+          add_field => {
+            "[@metadata][etl][pipeline]" => "filter-mutate-d306bc2dd122-20220824.01"
+          }
+          tag_on_failure => "_mutate_error-d306bc2dd122"
+          id => "filter-mutate-d306bc2dd122"
+        }
+      }
     }
 
   }


### PR DESCRIPTION
- typo, missing codec.](https://github.com/corelight/ecs-logstash-mappings/commit/b4f612e2d6e03707990461b0b251e5eb5cb5628e)
- change. make sure [log4j][target_port] is an integer, else remove as value would be "-"
- change. better network.direction logic. Also. convert conn.local_orig & conn.local_resp to strings (does not affect ES mappings), just makes for easier LS pipeline checking